### PR TITLE
Add a quick "Copy to Clipboard" context menu.

### DIFF
--- a/Diffusion-macOS/GeneratedImageView.swift
+++ b/Diffusion-macOS/GeneratedImageView.swift
@@ -36,9 +36,19 @@ struct GeneratedImageView: View {
                 return AnyView(Image(systemName: "exclamationmark.triangle").resizable())
             }
                               
-            return AnyView(Image(theImage, scale: 1, label: Text("generated"))
-                .resizable()
-                .clipShape(RoundedRectangle(cornerRadius: 20))
+            return AnyView(
+                    Image(theImage, scale: 1, label: Text("generated"))
+                    .resizable()
+                    .clipShape(RoundedRectangle(cornerRadius: 20))
+                    .contextMenu {
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            let nsimage = NSImage(cgImage: theImage, size: NSSize(width: theImage.width, height: theImage.height))
+                            NSPasteboard.general.writeObjects([nsimage])
+                        } label: {
+                            Text("Copy Photo")
+                        }
+                    }
             )
         case .failed(_):
             return AnyView(Image(systemName: "exclamationmark.triangle").resizable())


### PR DESCRIPTION
This PR adds a simple "Copy Photo" context menu which put the current generated photo into the clipboard.

Allowing the users to copy the photo to the clipboard makes it faster to quick share the photo to any app they want.

Example:
![image](https://user-images.githubusercontent.com/19654286/231614387-9dbf9452-55e6-428f-99de-b56bcb676334.png)
