### PR TITLE
PromptTextField

### DIFF
--- a/Diffusion-macOS/ControlsView.swift
+++ b/Diffusion-macOS/ControlsView.swift
@@ -73,6 +73,8 @@ struct ControlsView: View {
     @State private var showStepsHelp = false
     @State private var showSeedHelp = false
     @State private var showAdvancedHelp = false
+    @State private var positiveTokenCount: Int = 0
+    @State private var negativeTokenCount: Int = 0
 
     // Reasonable range for the slider
     let maxSeed: UInt32 = 1000
@@ -88,8 +90,8 @@ struct ControlsView: View {
     
     func resetComputeUnitsState() {
         generation.computeUnits = Settings.shared.userSelectedComputeUnits ?? ModelInfo.defaultComputeUnits
-    }
-    
+    }    
+
     func modelDidChange(model: ModelInfo) {
         guard pipelineLoader?.model != model || pipelineLoader?.computeUnits != generation.computeUnits else {
             print("Reusing same model \(model) with units \(generation.computeUnits)")
@@ -147,6 +149,19 @@ struct ControlsView: View {
         return selectedURL.path
     }
     
+    private func prompts() -> some View {
+        VStack {
+            Spacer()
+            PromptTextField(text: $generation.positivePrompt, isPositivePrompt: true, model: $model)
+                .padding(.top, 5)
+            Spacer()
+            PromptTextField(text: $generation.negativePrompt, isPositivePrompt: false, model: $model)
+                .padding(.bottom, 5)
+            Spacer()
+        }
+        .frame(maxHeight: .infinity)
+    }
+    
     var body: some View {
         VStack(alignment: .leading) {
             
@@ -196,13 +211,7 @@ struct ControlsView: View {
                     
                     DisclosureGroup(isExpanded: $disclosedPrompt) {
                         Group {
-                            TextField("Positive prompt", text: $generation.positivePrompt,
-                                      axis: .vertical).lineLimit(5)
-                                .textFieldStyle(.squareBorder)
-                                .listRowInsets(EdgeInsets(top: 0, leading: -20, bottom: 0, trailing: 20))
-                            TextField("Negative prompt", text: $generation.negativePrompt,
-                                      axis: .vertical).lineLimit(5)
-                                .textFieldStyle(.squareBorder)
+                            prompts()
                         }.padding(.leading, 10)
                     } label: {
                         HStack {
@@ -388,3 +397,4 @@ struct ControlsView: View {
         }
     }
 }
+

--- a/Diffusion-macOS/ControlsView.swift
+++ b/Diffusion-macOS/ControlsView.swift
@@ -90,7 +90,7 @@ struct ControlsView: View {
     
     func resetComputeUnitsState() {
         generation.computeUnits = Settings.shared.userSelectedComputeUnits ?? ModelInfo.defaultComputeUnits
-    }    
+    }
 
     func modelDidChange(model: ModelInfo) {
         guard pipelineLoader?.model != model || pipelineLoader?.computeUnits != generation.computeUnits else {

--- a/Diffusion.xcodeproj/project.pbxproj
+++ b/Diffusion.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8CD8A53A2A456EF800BD8A98 /* PromptTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD8A5392A456EF800BD8A98 /* PromptTextField.swift */; };
+		8CD8A53C2A476E2C00BD8A98 /* PromptTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD8A5392A456EF800BD8A98 /* PromptTextField.swift */; };
 		EB067F872992E561004D1AD9 /* HelpContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB067F862992E561004D1AD9 /* HelpContent.swift */; };
 		EB25B3D62A3A2DC4000E25A1 /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = EB25B3D52A3A2DC4000E25A1 /* StableDiffusion */; };
 		EB25B3D82A3A2DD5000E25A1 /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = EB25B3D72A3A2DD5000E25A1 /* StableDiffusion */; };
@@ -61,6 +63,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8CD8A5392A456EF800BD8A98 /* PromptTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PromptTextField.swift; sourceTree = "<group>"; };
 		EB067F862992E561004D1AD9 /* HelpContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpContent.swift; sourceTree = "<group>"; };
 		EB33A51E2954E1BC00B16357 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		EB560F0329A3C20800C0F8B8 /* Capabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capabilities.swift; sourceTree = "<group>"; };
@@ -134,6 +137,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8CD8A53B2A476E1C00BD8A98 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8CD8A5392A456EF800BD8A98 /* PromptTextField.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		8CF53E022A44AE0400E6358B /* Common */ = {
 			isa = PBXGroup;
 			children = (
@@ -142,6 +153,7 @@
 				EBDD7DB72976AAFE00C1C4B2 /* State.swift */,
 				EBDD7DB22973200200C1C4B2 /* Utils.swift */,
 				EBB5BA5129425B07003A2A5B /* Pipeline */,
+				8CD8A53B2A476E1C00BD8A98 /* Views */,
 			);
 			name = Common;
 			path = Diffusion/Common;
@@ -476,6 +488,7 @@
 				EBE756092941178600806B32 /* Loading.swift in Sources */,
 				EBDD7DB82976AAFE00C1C4B2 /* State.swift in Sources */,
 				EBB5BA5329425BEE003A2A5B /* PipelineLoader.swift in Sources */,
+				8CD8A53C2A476E2C00BD8A98 /* PromptTextField.swift in Sources */,
 				EBE755C9293E37DD00806B32 /* DiffusionApp.swift in Sources */,
 				EBDD7DB32973200200C1C4B2 /* Utils.swift in Sources */,
 			);
@@ -508,6 +521,7 @@
 				EBDD7DB92976AAFE00C1C4B2 /* State.swift in Sources */,
 				EB067F872992E561004D1AD9 /* HelpContent.swift in Sources */,
 				EBDD7DB42973200200C1C4B2 /* Utils.swift in Sources */,
+				8CD8A53A2A456EF800BD8A98 /* PromptTextField.swift in Sources */,
 				F1552031297109C300DC009B /* ControlsView.swift in Sources */,
 				EBDD7DB62973206600C1C4B2 /* Downloader.swift in Sources */,
 				F155203429710B3600DC009B /* StatusView.swift in Sources */,

--- a/Diffusion.xcodeproj/project.pbxproj
+++ b/Diffusion.xcodeproj/project.pbxproj
@@ -675,10 +675,13 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Diffusion/Preview Content\"";
+				DEVELOPMENT_TEAM = 9CPA8P59Z6;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Diffusion/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Diffusers;
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "To be able to save generated images to your Photo Library, you’ll need to allow this.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -693,6 +696,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.huggingface.Diffusers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -718,6 +722,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Diffusion/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Diffusers;
+				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "To be able to save generated images to your Photo Library, you’ll need to allow this.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/Diffusion.xcodeproj/project.pbxproj
+++ b/Diffusion.xcodeproj/project.pbxproj
@@ -675,13 +675,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Diffusion/Preview Content\"";
-				DEVELOPMENT_TEAM = 9CPA8P59Z6;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Diffusion/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Diffusers;
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "To be able to save generated images to your Photo Library, you’ll need to allow this.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -696,7 +693,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 13.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.huggingface.Diffusers;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -722,8 +718,6 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Diffusion/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Diffusers;
-				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "To be able to save generated images to your Photo Library, you’ll need to allow this.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/Diffusion/Common/Views/PromptTextField.swift
+++ b/Diffusion/Common/Views/PromptTextField.swift
@@ -86,7 +86,7 @@ struct PromptTextField: View {
                 .listRowInsets(EdgeInsets(top: 0, leading: -20, bottom: 0, trailing: 20))
                 .foregroundColor(textColor == .green ? .primary : textColor)
                 .frame(minHeight: 30)
-            if (modelInfo != nil && tokenizer != nil) {
+            if modelInfo != nil && tokenizer != nil {
                 HStack {
                     Spacer()
                     if !textBinding.isEmpty {

--- a/Diffusion/Common/Views/PromptTextField.swift
+++ b/Diffusion/Common/Views/PromptTextField.swift
@@ -69,7 +69,7 @@ struct PromptTextField: View {
         _model = model
     }
     
-    //iOS initializer
+    // iOS initializer
     init(text: Binding<String>, isPositivePrompt: Bool, model: String) {
         _textBinding = text
         self.isPositivePrompt = isPositivePrompt

--- a/Diffusion/Common/Views/PromptTextField.swift
+++ b/Diffusion/Common/Views/PromptTextField.swift
@@ -51,7 +51,6 @@ struct PromptTextField: View {
         return nil
     }
     
-    
     private var textColor: Color {
         switch tokenCount {
         case 0...65:
@@ -79,32 +78,46 @@ struct PromptTextField: View {
 
     var body: some View {
         VStack {
-            HStack {
-                Spacer()
-                if !textBinding.isEmpty {
-                    Text("\(tokenCount)")
-                        .foregroundColor(textColor)
-                    Text(" / \(maxTokenCount)")
-                }
-            }
-            .onReceive(Just(textBinding)) { text in
-                updateTokenCount(newText: text)
-            }
-            .font(.caption)
             #if os(macOS)
             TextField(isPositivePrompt ? "Positive prompt" : "Negative Prompt", text: $textBinding,
                       axis: .vertical)
                 .lineLimit(20)
                 .textFieldStyle(.squareBorder)
                 .listRowInsets(EdgeInsets(top: 0, leading: -20, bottom: 0, trailing: 20))
-                .foregroundColor(textColor == .green ? .white : textColor)
+                .foregroundColor(textColor == .green ? .primary : textColor)
                 .frame(minHeight: 30)
+            if (modelInfo != nil && tokenizer != nil) {
+                HStack {
+                    Spacer()
+                    if !textBinding.isEmpty {
+                        Text("\(tokenCount)")
+                            .foregroundColor(textColor)
+                        Text(" / \(maxTokenCount)")
+                    }
+                }
+                .onReceive(Just(textBinding)) { text in
+                    updateTokenCount(newText: text)
+                }
+                .font(.caption)
+            }
             #else
             TextField("Prompt", text: $textBinding, axis: .vertical)
                 .lineLimit(20)
                 .listRowInsets(EdgeInsets(top: 0, leading: -20, bottom: 0, trailing: 20))
-                .foregroundColor(textColor == .green ? .white : textColor)
+                .foregroundColor(textColor == .green ? .primary : textColor)
                 .frame(minHeight: 30)
+            HStack {
+                if !textBinding.isEmpty {
+                    Text("\(tokenCount)")
+                        .foregroundColor(textColor)
+                    Text(" / \(maxTokenCount)")
+                }
+                Spacer()
+            }
+            .onReceive(Just(textBinding)) { text in
+                updateTokenCount(newText: text)
+            }
+            .font(.caption)
             #endif
         }
         .onChange(of: model) { model in
@@ -113,10 +126,8 @@ struct PromptTextField: View {
     }
 
     private func updateTokenCount(newText: String) {
-        
         // ensure that the compiled URL exists
         guard let compiledURL = compiledURL else { return }
-
         // Initialize the tokenizer only when it's not created yet or the model changes
         // Check if the model version has changed
         let modelVersion = $model.wrappedValue

--- a/Diffusion/Common/Views/PromptTextField.swift
+++ b/Diffusion/Common/Views/PromptTextField.swift
@@ -123,6 +123,9 @@ struct PromptTextField: View {
         .onChange(of: model) { model in
             updateTokenCount(newText: textBinding)
         }
+        .onAppear {
+            updateTokenCount(newText: textBinding)
+        }
     }
 
     private func updateTokenCount(newText: String) {

--- a/Diffusion/Common/Views/PromptTextField.swift
+++ b/Diffusion/Common/Views/PromptTextField.swift
@@ -22,7 +22,7 @@ struct PromptTextField: View {
     @Binding var textBinding: String
     @Binding var model: String // the model version as it's stored in Settings
 
-    private let maxTokenCount = 75
+    private let maxTokenCount = 77
 
     private var modelInfo: ModelInfo? {
         ModelInfo.from(modelVersion: $model.wrappedValue)

--- a/Diffusion/Common/Views/PromptTextField.swift
+++ b/Diffusion/Common/Views/PromptTextField.swift
@@ -1,0 +1,141 @@
+//
+//  PromptTextField.swift
+//  Diffusion-macOS
+//
+//  Created by Dolmere on 22/06/2023.
+//  See LICENSE at https://github.com/huggingface/swift-coreml-diffusers/LICENSE
+//
+
+import SwiftUI
+import Combine
+import StableDiffusion
+
+struct PromptTextField: View {
+    @State private var output: String = ""
+    @State private var input: String = ""
+    @State private var typing = false
+    @State private var tokenCount: Int = 0
+    @State var isPositivePrompt: Bool = true
+    @State private var tokenizer: BPETokenizer?
+    @State private var currentModelVersion: String = ""
+
+    @Binding var textBinding: String
+    @Binding var model: String // the model version as it's stored in Settings
+
+    private let maxTokenCount = 75
+
+    private var modelInfo: ModelInfo? {
+        ModelInfo.from(modelVersion: $model.wrappedValue)
+    }
+    
+    private var filename: String? {
+        let variant = modelInfo?.bestAttention ?? .original
+        return modelInfo?.modelURL(for: variant).lastPathComponent
+    }
+    
+    private var downloadedURL: URL? {
+        if let filename = filename {
+            return PipelineLoader.models.appendingPathComponent(filename)
+        }
+        return nil
+    }
+    
+    private var packagesFilename: String? {
+        (filename as NSString?)?.deletingPathExtension
+    }
+    
+    private var compiledURL: URL? {
+        if let packagesFilename = packagesFilename {
+            return downloadedURL?.deletingLastPathComponent().appendingPathComponent(packagesFilename)
+        }
+        return nil
+    }
+    
+    
+    private var textColor: Color {
+        switch tokenCount {
+        case 0...65:
+            return .green
+        case 66...75:
+            return .orange
+        default:
+            return .red
+        }
+    }
+    
+    // macOS initializer
+    init(text: Binding<String>, isPositivePrompt: Bool, model: Binding<String>) {
+         _textBinding = text
+         self.isPositivePrompt = isPositivePrompt
+        _model = model
+    }
+    
+    //iOS initializer
+    init(text: Binding<String>, isPositivePrompt: Bool, model: String) {
+        _textBinding = text
+        self.isPositivePrompt = isPositivePrompt
+        _model = .constant(model)
+    }
+
+    var body: some View {
+        VStack {
+            HStack {
+                Spacer()
+                if !textBinding.isEmpty {
+                    Text("\(tokenCount)")
+                        .foregroundColor(textColor)
+                    Text(" / \(maxTokenCount)")
+                }
+            }
+            .onReceive(Just(textBinding)) { text in
+                updateTokenCount(newText: text)
+            }
+            .font(.caption)
+            #if os(macOS)
+            TextField(isPositivePrompt ? "Positive prompt" : "Negative Prompt", text: $textBinding,
+                      axis: .vertical)
+                .lineLimit(20)
+                .textFieldStyle(.squareBorder)
+                .listRowInsets(EdgeInsets(top: 0, leading: -20, bottom: 0, trailing: 20))
+                .foregroundColor(textColor == .green ? .white : textColor)
+                .frame(minHeight: 30)
+            #else
+            TextField("Prompt", text: $textBinding, axis: .vertical)
+                .lineLimit(20)
+                .listRowInsets(EdgeInsets(top: 0, leading: -20, bottom: 0, trailing: 20))
+                .foregroundColor(textColor == .green ? .white : textColor)
+                .frame(minHeight: 30)
+            #endif
+        }
+        .onChange(of: model) { model in
+            updateTokenCount(newText: textBinding)
+        }
+    }
+
+    private func updateTokenCount(newText: String) {
+        
+        // ensure that the compiled URL exists
+        guard let compiledURL = compiledURL else { return }
+
+        // Initialize the tokenizer only when it's not created yet or the model changes
+        // Check if the model version has changed
+        let modelVersion = $model.wrappedValue
+        if modelVersion != currentModelVersion {
+            do {
+                tokenizer = try BPETokenizer(
+                    mergesAt: compiledURL.appendingPathComponent("merges.txt"),
+                    vocabularyAt: compiledURL.appendingPathComponent("vocab.json")
+                )
+                currentModelVersion = modelVersion
+            } catch {
+                print("Failed to create tokenizer: \(error)")
+                return
+            }
+        }
+        let (tokens, _) = tokenizer?.tokenize(input: newText) ?? ([], [])
+
+        DispatchQueue.main.async {
+            self.tokenCount = tokens.count
+        }
+    }
+}

--- a/Diffusion/Views/TextToImage.swift
+++ b/Diffusion/Views/TextToImage.swift
@@ -113,7 +113,7 @@ struct TextToImage: View {
     var body: some View {
         VStack {
             HStack {
-                PromptTextField(text: $generation.positivePrompt, isPositivePrompt: true, model: ModelInfo.v21Base.modelVersion)
+                PromptTextField(text: $generation.positivePrompt, isPositivePrompt: true, model: deviceSupportsQuantization ? ModelInfo.v21Palettized.modelVersion : ModelInfo.v21Base.modelVersion)
                 Button("Generate") {
                     submit()
                 }

--- a/Diffusion/Views/TextToImage.swift
+++ b/Diffusion/Views/TextToImage.swift
@@ -113,11 +113,7 @@ struct TextToImage: View {
     var body: some View {
         VStack {
             HStack {
-                TextField("Prompt", text: $generation.positivePrompt)
-                    .textFieldStyle(.roundedBorder)
-                    .onSubmit {
-                        submit()
-                    }
+                PromptTextField(text: $generation.positivePrompt, isPositivePrompt: true, model: ModelInfo.v21Base.modelVersion)
                 Button("Generate") {
                     submit()
                 }


### PR DESCRIPTION
https://github.com/huggingface/swift-coreml-diffusers/issues/53 Rather than limiting the prompt entry on textfield size limits or character limits this PR adds a token tracker.

As the user enters prompts an indicator displays the current number of used tokens versus the maximum of 75.

Tokens are calculated using the currently selected model.

For the moment this is a short term goal to  expose the token count to the end user with a change of text color to warn of approaching or exceeding mac token count.

Note that in a1111 they handle this by merging excessive tokens. "AUTOMATIC1111 has no token limits. If a prompt contains more than 75 tokens, the limit of the CLIP tokenizer, it will start a new chunk of another 75 tokens, so the new “limit” becomes 150. The process can continue forever or until your computer runs out of memory…

Each chunk of 75 tokens is processed independently, and the resulting representations are concatenated before feeding into Stable Diffusion’s U-Net."

<img width="1100" alt="Screenshot 2023-06-24 at 20 30 08" src="https://github.com/huggingface/swift-coreml-diffusers/assets/47501428/19c19119-42c4-463d-b227-b185cb587082">

<img width="1100" alt="Screenshot 2023-06-24 at 20 28 52" src="https://github.com/huggingface/swift-coreml-diffusers/assets/47501428/7b68cf77-70bc-41bd-93ed-73bd42934abc">

<img width="1100" alt="Screenshot 2023-06-24 at 20 24 36" src="https://github.com/huggingface/swift-coreml-diffusers/assets/47501428/66c3aa1d-9930-4edb-bcd6-9faa4f4d3249">
