### PR TITLE
macOS batch image creation

### DIFF
--- a/Diffusion-macOS/ContentView.swift
+++ b/Diffusion-macOS/ContentView.swift
@@ -64,11 +64,15 @@ struct ShareButtons: View {
 
 struct ContentView: View {
     @StateObject var generation = GenerationContext()
-
+    @StateObject var imageViewModel = ImageViewObservableModel.shared
+    
     func toolbar() -> any View {
-        if case .complete(let prompt, let cgImage, _, _) = generation.state, let cgImage = cgImage {
+        if case .complete(let prompt, let cgImage, _, _) = generation.state {
             // TODO: share seed too
-            return ShareButtons(image: cgImage, name: prompt)
+            if let img = cgImage.first {
+                return ShareButtons(image: img!, name: prompt)
+            }
+            return AnyView(EmptyView())
         } else {
             let prompt = DEFAULT_PROMPT
             let cgImage = NSImage(imageLiteralResourceName: "placeholder").cgImage(forProposedRect: nil, context: nil, hints: nil)!
@@ -91,6 +95,7 @@ struct ContentView: View {
 
         }
         .environmentObject(generation)
+        .environmentObject(imageViewModel)
     }
 }
 

--- a/Diffusion-macOS/ControlsView.swift
+++ b/Diffusion-macOS/ControlsView.swift
@@ -56,6 +56,7 @@ struct ControlsView: View {
     @State private var disclosedGuidance = false
     @State private var disclosedSteps = false
     @State private var disclosedSeed = false
+    @State private var disclosedImageCount = false
     @State private var disclosedAdvanced = false
 
     // TODO: refactor download with similar code in Loading.swift (iOS)
@@ -145,6 +146,17 @@ struct ControlsView: View {
         let selectedURL = pipelineLoader.compiledURL
         guard FileManager.default.fileExists(atPath: selectedURL.path) else { return nil }
         return selectedURL.path
+    }
+    
+    func batchImageCount() -> some View {
+        HStack {
+            CompactSlider(value: Binding<Double>(get: { Double(generation.imageCount) }, set: { generation.imageCount = Double($0) }), in: 0...100) {
+                Text("Batch Size")
+                Spacer()
+                Text("\(Int(generation.imageCount))")
+            }
+            Stepper("", value: $generation.imageCount, in: 1...100)
+        }.foregroundColor(.secondary)
     }
     
     var body: some View {
@@ -302,6 +314,15 @@ struct ControlsView: View {
                             } else {
                                 Text("\(Int(generation.seed))")
                             }
+                        }.foregroundColor(.secondary)
+                    }
+                                        
+                    DisclosureGroup(isExpanded: $disclosedImageCount) {
+                        batchImageCount()
+                    } label: {
+                        HStack {
+                            Label("Image Count", systemImage: "photo.stack").foregroundColor(.secondary)
+                            Spacer()
                         }.foregroundColor(.secondary)
                     }
                     

--- a/Diffusion-macOS/GeneratedImageView.swift
+++ b/Diffusion-macOS/GeneratedImageView.swift
@@ -10,10 +10,67 @@ import SwiftUI
 
 struct GeneratedImageView: View {
     @EnvironmentObject var generation: GenerationContext
+    @EnvironmentObject var imageViewModel: ImageViewObservableModel
+    
+    func completeView(generatedImages: [CGImage?]) -> some View {
+        if generatedImages.count == 0 {
+            return AnyView(
+                Image(systemName: "exclamationmark.triangle")
+                    .resizable()
+            )
+        } else if generatedImages.count == 1 {
+            DispatchQueue.main.async {
+                imageViewModel.currentBuildImages = DiffusionImage.fromCGImages(generatedImages, seed: generation.seed, steps: generation.steps, prompt: generation.positivePrompt, negativePrompt: generation.negativePrompt, scheduler: generation.scheduler, guidanceScale: generation.guidanceScale, disableSafety: generation.disableSafety)
+            }
+            if let img = imageViewModel.currentBuildImages.first?.cgImage {
+                if let diffusionImage = DiffusionImage.fromCGImages([img], seed: generation.seed, steps: generation.steps, prompt: generation.positivePrompt, negativePrompt: generation.negativePrompt, scheduler: generation.scheduler, guidanceScale: generation.guidanceScale, disableSafety: generation.disableSafety).first {
+                    return AnyView(SingleGeneratedImageView(generatedImage: diffusionImage )
+                        .aspectRatio(contentMode: .fit)
+                        .cornerRadius(15)
+                        .environmentObject(imageViewModel)
+                    )
+                }
+                // DiffusionImage failed to create
+                // Display error condition for image not found
+                return AnyView( Image(systemName: "exclamationmark.triangle")
+                        .resizable()
+                        .foregroundColor(.orange)
+                )
+
+            }
+            // Generated image is missing
+            // Display error condition for image not found, either a generation error or safety checker triggered
+            return AnyView( Image(systemName: "exclamationmark.triangle")
+                    .resizable()
+                    .foregroundColor(.red)
+            )
+        } else {
+            DispatchQueue.main.async {
+                imageViewModel.currentBuildImages = DiffusionImage.fromCGImages(generatedImages, seed: generation.seed, steps: generation.steps, prompt: generation.positivePrompt, negativePrompt: generation.negativePrompt, scheduler: generation.scheduler, guidanceScale: generation.guidanceScale, disableSafety: generation.disableSafety)
+            }
+                if let _ = imageViewModel.currentBuildImages.first?.cgImage {
+                    
+                    return AnyView( MultipleGeneratedImagesView(generatedImages: imageViewModel.currentBuildImages)
+                        .aspectRatio(contentMode: .fit)
+                        .cornerRadius(15)
+                        .environmentObject(imageViewModel)
+                    )
+                }
+            
+            // Display error condition for image not found
+            return AnyView( Image(systemName: "exclamationmark.triangle")
+                    .resizable()
+                    .foregroundColor(.orange)
+            )
+        }
+    }
     
     var body: some View {
         switch generation.state {
-        case .startup: return AnyView(Image("placeholder").resizable())
+        case .startup: return AnyView(
+            Image("placeholder")
+                .resizable()
+            )
         case .running(let progress):
             guard let progress = progress, progress.stepCount > 0 else {
                 // The first time it takes a little bit before generation starts
@@ -21,35 +78,13 @@ struct GeneratedImageView: View {
             }
             let step = Int(progress.step) + 1
             let fraction = Double(step) / Double(progress.stepCount)
+            //TODO: If multiple images are being generated then either create multiple progress bars, one per image, or multiply the step count yb the number of images... -- Dolmere
             let label = "Step \(step) of \(progress.stepCount)"
             return AnyView(HStack {
                 ProgressView(label, value: fraction, total: 1).padding()
-                Button {
-                    generation.cancelGeneration()
-                } label: {
-                    Image(systemName: "x.circle.fill").foregroundColor(.gray)
-                }
-                .buttonStyle(.plain)
             })
-        case .complete(_, let image, _, _):
-            guard let theImage = image else {
-                return AnyView(Image(systemName: "exclamationmark.triangle").resizable())
-            }
-                              
-            return AnyView(
-                    Image(theImage, scale: 1, label: Text("generated"))
-                    .resizable()
-                    .clipShape(RoundedRectangle(cornerRadius: 20))
-                    .contextMenu {
-                        Button {
-                            NSPasteboard.general.clearContents()
-                            let nsimage = NSImage(cgImage: theImage, size: NSSize(width: theImage.width, height: theImage.height))
-                            NSPasteboard.general.writeObjects([nsimage])
-                        } label: {
-                            Text("Copy Photo")
-                        }
-                    }
-            )
+        case .complete(_, let generatedImages, _, _):
+            return AnyView(completeView(generatedImages: generatedImages))
         case .failed(_):
             return AnyView(Image(systemName: "exclamationmark.triangle").resizable())
         case .userCanceled:

--- a/Diffusion-macOS/MultipleGeneratedImagesView.swift
+++ b/Diffusion-macOS/MultipleGeneratedImagesView.swift
@@ -1,0 +1,34 @@
+//
+//  MultipleGeneratedImagesView.swift
+//  Diffusion-macOS
+//
+//  Created by Dolmere on 14/06/2023.
+//  See LICENSE at https://github.com/huggingface/swift-coreml-diffusers/LICENSE
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct MultipleGeneratedImagesView: View {
+    
+    @State var generatedImages: [DiffusionImage?]
+    @State private var gridColumns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 3)
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                LazyVGrid(columns: gridColumns) {
+                    ForEach(generatedImages, id:\.self) { genImage in
+                        if let diffusionImage = genImage {
+                            SingleGeneratedImageView(generatedImage: diffusionImage)
+                        } else {
+                            AnyView(Text("Missing image!"))
+                        }
+                    }
+                }
+                .frame(minWidth: 0, maxWidth: .infinity) // Ensure the grid occupies full width
+            }
+            .frame(width: geometry.size.width, height: geometry.size.height) // Match parent size
+        }
+    }
+}

--- a/Diffusion-macOS/SingleGeneratedImageView.swift
+++ b/Diffusion-macOS/SingleGeneratedImageView.swift
@@ -1,0 +1,105 @@
+//
+//  SingleGeneratedImageView.swift
+//  Diffusion-macOS
+//
+//  Created by Dolmere on 14/06/2023.
+//  See LICENSE at https://github.com/huggingface/swift-coreml-diffusers/LICENSE
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+#if os(macOS)
+import AppKit
+#endif
+
+struct SingleGeneratedImageView: View {
+    @EnvironmentObject var generation: GenerationContext
+    @EnvironmentObject var imageViewModel: ImageViewObservableModel
+    @State var generatedImage: DiffusionImage
+    
+    var cgImage: CGImage {
+        if let returnImage = generatedImage.cgImage {
+            return returnImage
+        }
+        if let symbolImage = NSImage(systemSymbolName: "exclamationmark.triangle", accessibilityDescription: nil) {
+            if let cgImage = symbolImage.cgImage(forProposedRect: nil, context: nil, hints: nil) {
+                return cgImage
+            }
+        }
+        // Return a default CGImage if none of the conditions are met
+        return CGImage(width: 1, height: 1, bitsPerComponent: 8, bitsPerPixel: 32, bytesPerRow: 4, space: CGColorSpaceCreateDeviceRGB(), bitmapInfo: CGBitmapInfo(rawValue: CGBitmapInfo.byteOrder32Little.rawValue | CGImageAlphaInfo.premultipliedFirst.rawValue) , provider: CGDataProvider(data: NSData(bytes: [0, 0, 0, 0], length: 4) as CFData)!, decode: nil, shouldInterpolate: true, intent: .defaultIntent)!
+    }
+        
+    var body: some View {
+        Image(nsImage: NSImage(cgImage: cgImage , size: CGSize(width: cgImage.width, height: cgImage.height)))
+            .resizable()
+            .aspectRatio(1, contentMode: .fit)
+            .clipShape(RoundedRectangle(cornerRadius: 15))
+            .onDrag {
+                guard let tiffData = NSImage(cgImage: cgImage, size: CGSize(width: cgImage.width, height: cgImage.height)).tiffRepresentation,
+                      let bitmap = NSBitmapImageRep(data: tiffData),
+                      let pngData = bitmap.representation(using: .png, properties: [:]) else {
+                    return NSItemProvider()
+                }
+                
+                let itemProvider = NSItemProvider()
+                itemProvider.registerDataRepresentation(forTypeIdentifier: UTType.tiff.identifier, visibility: .all) { completion in
+                    completion(tiffData, nil)
+                    return nil
+                }
+                
+                itemProvider.registerDataRepresentation(forTypeIdentifier: UTType.png.identifier, visibility: .all) { completion in
+                    completion(pngData, nil)
+                    return nil
+                }
+                
+                if let fileURL = imageViewModel.createTempFile(image: NSImage(cgImage: cgImage, size: CGSize(width: cgImage.width, height: cgImage.height))) {
+                    let fileURLData = fileURL.absoluteString.data(using: .utf8)
+                    itemProvider.registerDataRepresentation(forTypeIdentifier: NSPasteboard.PasteboardType.fileURL.rawValue, visibility: .all) { completion in
+                        completion(fileURLData, nil)
+                        return nil
+                    }
+                    return itemProvider
+                }
+                
+                return NSItemProvider()
+            }
+            .onDisappear {
+                for fileURL in imageViewModel.tempFilesCreated {
+                    do {
+                        try FileManager.default.removeItem(at: fileURL)
+                    } catch {
+                        print("Error removing temporary file: \(error)")
+                    }
+                }
+                // empty the tracked temp files array
+                imageViewModel.tempFilesCreated.removeAll()
+            }
+            .contextMenu {
+                Button {
+                    let pb = NSPasteboard.general
+                    if let fileURL = imageViewModel.createTempFile(image: NSImage(cgImage: cgImage, size: CGSize(width: cgImage.width, height: cgImage.height))) {
+                        do {
+                            let resourceValues = try fileURL.resourceValues(forKeys: [.contentTypeKey])
+                            if let contentType = resourceValues.contentType {
+                                let pasteboardType = NSPasteboard.PasteboardType(contentType.identifier)
+                                pb.declareTypes([pasteboardType], owner: nil)
+                                pb.writeObjects([fileURL as NSURL])
+                            }
+                        } catch {
+                            print("cannot copy to pasteboard")
+                            return
+                        }
+                    } else {
+                        print("cannot make temp file")
+                    }
+                } label: {
+                    Label("Copy", systemImage: "square.and.arrow.down")
+                }
+            }
+            .onTapGesture {
+                imageViewModel.toggleSelection(for: generatedImage)
+            }
+            .border(imageViewModel.selectedImages.contains(generatedImage) ? Color.blue : Color.clear, width: 2)
+        }
+}

--- a/Diffusion-macOS/StatusView.swift
+++ b/Diffusion-macOS/StatusView.swift
@@ -23,7 +23,7 @@ struct StatusView: View {
                 if result.userCanceled {
                     generation.state = .userCanceled
                 } else {
-                    generation.state = .complete(generation.positivePrompt, result.image, result.lastSeed, result.interval)
+                    generation.state = .complete(generation.positivePrompt, result.images, result.lastSeed, result.interval)
                 }
             } catch {
                 generation.state = .failed(error)
@@ -75,8 +75,8 @@ struct StatusView: View {
                 Text("Generating \(Int(round(100*fraction)))%")
                 Spacer()
             }
-        case .complete(_, let image, let lastSeed, let interval):
-            guard let _ = image else {
+        case .complete(_, let images, let lastSeed, let interval):
+            guard let _ = images.first else {
                 return HStack {
                     Text("Safety checker triggered, please try a different prompt or seed.")
                     Spacer()

--- a/Diffusion.xcodeproj/project.pbxproj
+++ b/Diffusion.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8CD8A53E2A47807F00BD8A98 /* SingleGeneratedImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD8A53D2A47807F00BD8A98 /* SingleGeneratedImageView.swift */; };
+		8CD8A5402A4780CF00BD8A98 /* ImageViewObservableModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD8A53F2A4780CF00BD8A98 /* ImageViewObservableModel.swift */; };
+		8CD8A5412A4780CF00BD8A98 /* ImageViewObservableModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD8A53F2A4780CF00BD8A98 /* ImageViewObservableModel.swift */; };
+		8CD8A5442A47910600BD8A98 /* MultipleGeneratedImagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD8A5422A47910600BD8A98 /* MultipleGeneratedImagesView.swift */; };
 		EB067F872992E561004D1AD9 /* HelpContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB067F862992E561004D1AD9 /* HelpContent.swift */; };
 		EB25B3D62A3A2DC4000E25A1 /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = EB25B3D52A3A2DC4000E25A1 /* StableDiffusion */; };
 		EB25B3D82A3A2DD5000E25A1 /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = EB25B3D72A3A2DD5000E25A1 /* StableDiffusion */; };
@@ -61,6 +65,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8CD8A53D2A47807F00BD8A98 /* SingleGeneratedImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleGeneratedImageView.swift; sourceTree = "<group>"; };
+		8CD8A53F2A4780CF00BD8A98 /* ImageViewObservableModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewObservableModel.swift; sourceTree = "<group>"; };
+		8CD8A5422A47910600BD8A98 /* MultipleGeneratedImagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleGeneratedImagesView.swift; sourceTree = "<group>"; };
 		EB067F862992E561004D1AD9 /* HelpContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpContent.swift; sourceTree = "<group>"; };
 		EB33A51E2954E1BC00B16357 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		EB560F0329A3C20800C0F8B8 /* Capabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capabilities.swift; sourceTree = "<group>"; };
@@ -141,6 +148,7 @@
 				EBE3FF4B295E1EFE00E921AA /* ModelInfo.swift */,
 				EBDD7DB72976AAFE00C1C4B2 /* State.swift */,
 				EBDD7DB22973200200C1C4B2 /* Utils.swift */,
+				8CD8A53F2A4780CF00BD8A98 /* ImageViewObservableModel.swift */,
 				EBB5BA5129425B07003A2A5B /* Pipeline */,
 			);
 			name = Common;
@@ -253,6 +261,8 @@
 				F15520232971093300DC009B /* Diffusion_macOSApp.swift */,
 				F15520252971093300DC009B /* ContentView.swift */,
 				EBDD7DBB2977FFB300C1C4B2 /* GeneratedImageView.swift */,
+				8CD8A53D2A47807F00BD8A98 /* SingleGeneratedImageView.swift */,
+				8CD8A5422A47910600BD8A98 /* MultipleGeneratedImagesView.swift */,
 				F1552030297109C300DC009B /* ControlsView.swift */,
 				F155203329710B3600DC009B /* StatusView.swift */,
 				EB067F862992E561004D1AD9 /* HelpContent.swift */,
@@ -476,6 +486,7 @@
 				EBE756092941178600806B32 /* Loading.swift in Sources */,
 				EBDD7DB82976AAFE00C1C4B2 /* State.swift in Sources */,
 				EBB5BA5329425BEE003A2A5B /* PipelineLoader.swift in Sources */,
+				8CD8A5402A4780CF00BD8A98 /* ImageViewObservableModel.swift in Sources */,
 				EBE755C9293E37DD00806B32 /* DiffusionApp.swift in Sources */,
 				EBDD7DB32973200200C1C4B2 /* Utils.swift in Sources */,
 			);
@@ -510,10 +521,13 @@
 				EBDD7DB42973200200C1C4B2 /* Utils.swift in Sources */,
 				F1552031297109C300DC009B /* ControlsView.swift in Sources */,
 				EBDD7DB62973206600C1C4B2 /* Downloader.swift in Sources */,
+				8CD8A5442A47910600BD8A98 /* MultipleGeneratedImagesView.swift in Sources */,
 				F155203429710B3600DC009B /* StatusView.swift in Sources */,
 				EB560F0429A3C20800C0F8B8 /* Capabilities.swift in Sources */,
 				F15520242971093300DC009B /* Diffusion_macOSApp.swift in Sources */,
 				EBDD7DB52973201800C1C4B2 /* ModelInfo.swift in Sources */,
+				8CD8A5412A4780CF00BD8A98 /* ImageViewObservableModel.swift in Sources */,
+				8CD8A53E2A47807F00BD8A98 /* SingleGeneratedImageView.swift in Sources */,
 				EBDD7DBD2977FFB300C1C4B2 /* GeneratedImageView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Diffusion/Common/ImageViewObservableModel.swift
+++ b/Diffusion/Common/ImageViewObservableModel.swift
@@ -1,0 +1,117 @@
+//
+//  ImageViewObservableModel.swift
+//  Diffusion
+//
+//  Created by Dolmere on 14/06/2023.
+//  See LICENSE at https://github.com/huggingface/swift-coreml-diffusers/LICENSE
+//
+
+import SwiftUI
+import StableDiffusion
+
+// Model to capture generated image data
+struct DiffusionImage: Identifiable, Hashable, Equatable {
+    let id = UUID()
+    let cgImage: CGImage?
+    let seed: Double
+    let steps: Double
+    let prompt: String
+    let negativePrompt: String
+    let scheduler: StableDiffusionScheduler
+    let guidanceScale: Double
+    let disableSafety: Bool
+
+    // Function to create an array of DiffusionImage from an array of CGImage?
+    static func fromCGImages(_ cgImages: [CGImage?], seed: Double, steps: Double, prompt: String, negativePrompt: String, scheduler: StableDiffusionScheduler, guidanceScale: Double, disableSafety: Bool) -> [DiffusionImage] {
+        var diffusionImages: [DiffusionImage] = []
+        
+        for cgImage in cgImages {
+            if let image = cgImage {
+                let diffusionImage = DiffusionImage(
+                    cgImage: image,
+                    seed: seed,
+                    steps: steps,
+                    prompt: prompt,
+                    negativePrompt: negativePrompt,
+                    scheduler: scheduler,
+                    guidanceScale: guidanceScale,
+                    disableSafety: disableSafety
+                )
+                diffusionImages.append(diffusionImage)
+            }
+        }
+        
+        return diffusionImages
+    }
+}
+
+class ImageViewObservableModel: ObservableObject {
+    @Published var selectedImages: Set<DiffusionImage> = []
+    @Published var currentBuildImages: [DiffusionImage] = []
+    @Published var tempFilesCreated: [URL] = []
+
+    static let shared: ImageViewObservableModel = ImageViewObservableModel()
+    
+    private init() {}
+    
+    /// clear the cachedImages
+    func reset() {
+        //TODO: add save, autosave, etc...
+        // on save write pipeline data into the PNG file
+        currentBuildImages = []
+    }
+    
+    func toggleSelection(for image: DiffusionImage) {
+        if selectedImages.contains(image) {
+            selectedImages.remove(image)
+        } else {
+            selectedImages.insert(image)
+        }
+    }
+    
+    #if os(macOS)
+    func createTempFile(image: NSImage?) -> URL? {
+        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("png")
+        
+        // Save the image as a temporary file
+        if let tiffData = image?.tiffRepresentation,
+           let bitmap = NSBitmapImageRep(data: tiffData),
+           let pngData = bitmap.representation(using: .png, properties: [:]) {
+            do {
+                try pngData.write(to: fileURL)
+                self.tempFilesCreated.append(fileURL)
+                return fileURL
+            } catch {
+                print("Error saving image to temporary file: \(error)")
+            }
+        }
+        return nil
+    }
+    #else
+    func createTempFile(image: UIImage?) -> URL? {
+        guard let image = image else {
+            return nil
+        }
+        
+        let fileManager = FileManager.default
+        let temporaryDirectoryURL = URL(fileURLWithPath: NSTemporaryDirectory())
+        let fileURL = temporaryDirectoryURL
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("png")
+        
+        if let imageData = image.pngData() {
+            do {
+                try imageData.write(to: fileURL)
+                self.tempFilesCreated.append(fileURL)
+                return fileURL
+            } catch {
+                print("Error saving image to temporary file: \(error)")
+            }
+        }
+        
+        return nil
+    }
+    #endif
+}

--- a/Diffusion/Common/Pipeline/Pipeline.swift
+++ b/Diffusion/Common/Pipeline/Pipeline.swift
@@ -15,7 +15,7 @@ import StableDiffusion
 typealias StableDiffusionProgress = StableDiffusionPipeline.Progress
 
 struct GenerationResult {
-    var image: CGImage?
+    var images: [CGImage?]
     var lastSeed: UInt32
     var interval: TimeInterval?
     var userCanceled: Bool
@@ -45,6 +45,7 @@ class Pipeline {
         negativePrompt: String = "",
         scheduler: StableDiffusionScheduler,
         numInferenceSteps stepCount: Int = 50,
+        imageCount: Double,
         seed: UInt32? = nil,
         guidanceScale: Float = 7.5,
         disableSafety: Bool = false
@@ -59,6 +60,7 @@ class Pipeline {
         var config = StableDiffusionPipeline.Configuration(prompt: prompt)
         config.negativePrompt = negativePrompt
         config.stepCount = stepCount
+        config.imageCount = Int(imageCount)
         config.seed = theSeed
         config.guidanceScale = guidanceScale
         config.disableSafety = disableSafety
@@ -75,9 +77,8 @@ class Pipeline {
         let interval = Date().timeIntervalSince(beginDate)
         print("Got images: \(images) in \(interval)")
         
-        // Unwrap the 1 image we asked for, nil means safety checker triggered
-        let image = images.compactMap({ $0 }).first
-        return GenerationResult(image: image, lastSeed: theSeed, interval: interval, userCanceled: canceled, itsPerSecond: 1.0/sampleTimer.median)
+        // Unwrap the images we asked for, nil means safety checker triggered
+        return GenerationResult(images: images, lastSeed: theSeed, interval: interval, userCanceled: canceled, itsPerSecond: 1.0/sampleTimer.median)
     }
 
     func handleProgress(_ progress: StableDiffusionPipeline.Progress, sampleTimer: SampleTimer) {

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -17,7 +17,7 @@ let DEFAULT_PROMPT = "Labrador in the style of Vermeer"
 enum GenerationState {
     case startup
     case running(StableDiffusionProgress?)
-    case complete(String, CGImage?, UInt32, TimeInterval?)
+    case complete(String, [CGImage?], UInt32, TimeInterval?)
     case userCanceled
     case failed(Error)
 }
@@ -47,7 +47,7 @@ class GenerationContext: ObservableObject {
     
     // FIXME: Double to support the slider component
     @Published var steps = 25.0
-    @Published var numImages = 1.0
+    @Published var imageCount = 1.0
     @Published var seed = -1.0
     @Published var guidanceScale = 7.5
     @Published var disableSafety = false
@@ -64,6 +64,7 @@ class GenerationContext: ObservableObject {
             negativePrompt: negativePrompt,
             scheduler: scheduler,
             numInferenceSteps: Int(steps),
+            imageCount: imageCount,
             seed: seed,
             guidanceScale: Float(guidanceScale),
             disableSafety: disableSafety

--- a/Diffusion/Views/TextToImage.swift
+++ b/Diffusion/Views/TextToImage.swift
@@ -66,11 +66,15 @@ struct ImageWithPlaceholder: View {
             let fraction = Double(step) / Double(progress.stepCount)
             let label = "Step \(step) of \(progress.stepCount)"
             return AnyView(ProgressView(label, value: fraction, total: 1).padding())
-        case .complete(let lastPrompt, let image, _, let interval):
-            guard let theImage = image else {
+        case .complete(let lastPrompt, let images, _, let interval):
+            guard let firstImage = images.first else {
                 return AnyView(Image(systemName: "exclamationmark.triangle").resizable())
             }
-                              
+
+            guard let theImage = firstImage else {
+                return AnyView(Image(systemName: "exclamationmark.triangle").resizable())
+            }
+            
             let imageView = Image(theImage, scale: 1, label: Text("generated"))
             return AnyView(
                 VStack {
@@ -103,7 +107,7 @@ struct TextToImage: View {
             generation.state = .running(nil)
             do {
                 let result = try await generation.generate()
-                generation.state = .complete(generation.positivePrompt, result.image, result.lastSeed, result.interval)
+                generation.state = .complete(generation.positivePrompt, result.images, result.lastSeed, result.interval)
             } catch {
                 generation.state = .failed(error)
             }


### PR DESCRIPTION
Adding a new batch image creation feature as requested in https://github.com/huggingface/swift-coreml-diffusers/issues/52

note: That there is a missing requested feature.
This PR generates a batch of images.
This PR does NOT yet have the following features:
- select one of the images to share individually (it shares the first generated image)
- define the seed that was used for each image in the batch
- use a starting seed and increment by one for each image in the batch

It DOES serve as a starting point to view the results of multiple images generated in a batch on macOS.