### PR TITLE
Application support path fix

### DIFF
--- a/Diffusion-macOS/ControlsView.swift
+++ b/Diffusion-macOS/ControlsView.swift
@@ -107,7 +107,6 @@ struct ControlsView: View {
                 DispatchQueue.main.async {
                     switch state {
                     case .downloading(let progress):
-                        print("\(loader.model.modelVersion): \(progress)")
                         pipelineState = .downloading(progress)
                     case .uncompressing:
                         pipelineState = .uncompressing
@@ -383,7 +382,6 @@ struct ControlsView: View {
         }
         .padding()
         .onAppear {
-            print(PipelineLoader.models)
             modelDidChange(model: ModelInfo.from(modelVersion: model) ?? ModelInfo.v2Base)
         }
     }

--- a/Diffusion/Common/Pipeline/Pipeline.swift
+++ b/Diffusion/Common/Pipeline/Pipeline.swift
@@ -51,7 +51,7 @@ class Pipeline {
     ) throws -> GenerationResult {
         let beginDate = Date()
         canceled = false
-        print("Generating...")
+
         let theSeed = seed ?? UInt32.random(in: 0...maxSeed)
         let sampleTimer = SampleTimer()
         sampleTimer.start()

--- a/Diffusion/Common/Pipeline/PipelineLoader.swift
+++ b/Diffusion/Common/Pipeline/PipelineLoader.swift
@@ -14,7 +14,7 @@ import ZIPFoundation
 import StableDiffusion
 
 class PipelineLoader {
-    static let models = URL.applicationSupportDirectory.appendingPathComponent("hf-diffusion-models")
+    static let models = Settings.shared.applicationSupportURL().appendingPathComponent("hf-diffusion-models")
     let model: ModelInfo
     let computeUnits: ComputeUnits
     let maxSeed: UInt32

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -126,4 +126,25 @@ class Settings {
             return ComputeUnits(rawValue: current)
         }
     }
+    
+    public func applicationSupportURL() -> URL {
+        let fileManager = FileManager.default
+        guard let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            // To ensure we don't return an optional - if the user domain application support cannot be accessed use the top level application support directory
+            return URL.applicationSupportDirectory
+        }
+
+        let appBundleIdentifier = Bundle.main.bundleIdentifier ?? ""
+        let appDirectoryURL = appSupportURL.appendingPathComponent(appBundleIdentifier)
+
+        do {
+            // Create the application support directory if it doesn't exist
+            try fileManager.createDirectory(at: appDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+            return appDirectoryURL
+        } catch {
+            print("Error creating application support directory: \(error)")
+            return fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        }
+    }
+
 }

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -129,13 +129,10 @@ class Settings {
     
     public func applicationSupportURL() -> URL {
         let fileManager = FileManager.default
-        guard let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+        guard let appDirectoryURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
             // To ensure we don't return an optional - if the user domain application support cannot be accessed use the top level application support directory
             return URL.applicationSupportDirectory
         }
-
-        let appBundleIdentifier = Bundle.main.bundleIdentifier ?? ""
-        let appDirectoryURL = appSupportURL.appendingPathComponent(appBundleIdentifier)
 
         do {
             // Create the application support directory if it doesn't exist


### PR DESCRIPTION
I discovered that post Path.swift fix the location of the default models folder was inconsistent. This PR creates a new internal API to access the user domain applicationSupportDirectory to improve consistency. If there is an issue with the user domain then this code will fall back to URL.applicationSupportDirectory but under normal operating conditions it should use the app bundle.

In the previous code I was using URL.applicationSupportDirectory directly which results in /Users/<uname>/Library/Application Support/hs-diffusion-models

Whereas the previous and correct usage is
/Users/<uname>/Library/Application Support/<bundle identifier>hf-diffusion-models

I've put the new applicationSupportURL function inside Settings. To access it use Settings.shared.applicationSupportURL()

Is Settings.shared a reasonable location for such an API? It's not quite a Util function.

(Note: this is extracted from the last commit to https://github.com/huggingface/swift-coreml-diffusers/pull/59 and should commit before and then merge back into 59 before it's reviewed.)