### PR TITLE
Model importer

### DIFF
--- a/Diffusion-macOS/ControlsView.swift
+++ b/Diffusion-macOS/ControlsView.swift
@@ -158,25 +158,47 @@ struct ControlsView: View {
             ScrollView {
                 Group {
                     DisclosureGroup(isExpanded: $disclosedModel) {
-                        let revealOption = "-- reveal --"
-                        Picker("", selection: $model) {
-                            ForEach(Self.models, id: \.modelVersion) {
-                                modelLabel($0)
+                        HStack {
+                            let revealOption = "-- reveal --"
+                            Picker("", selection: $model) {
+                                ForEach(Self.models, id: \.modelVersion) {
+                                    modelLabel($0)
+                                }
+                                Text("Reveal in Finder…").tag(revealOption)
                             }
-                            Text("Reveal in Finder…").tag(revealOption)
-                        }
-                        .onChange(of: model) { selection in
-                            guard selection != revealOption else {
-                                NSWorkspace.shared.selectFile(modelFilename, inFileViewerRootedAtPath: PipelineLoader.models.path)
-                                model = Settings.shared.currentModel.modelVersion
-                                return
+                            .onChange(of: model) { selection in
+                                guard selection != revealOption else {
+                                    NSWorkspace.shared.selectFile(modelFilename, inFileViewerRootedAtPath: PipelineLoader.models.path)
+                                    model = Settings.shared.currentModel.modelVersion
+                                    return
+                                }
+                                guard let model = ModelInfo.from(modelVersion: selection) else { return }
+                                modelDidChange(model: model)
                             }
-                            guard let model = ModelInfo.from(modelVersion: selection) else { return }
-                            modelDidChange(model: model)
+                            Button {
+                                // Set the central singleton instance to ensure that the info panel state can be updated from anywhere in the app
+                                Settings.shared.isShowingImportPanel = true
+                            } label: {
+                                Image(systemName: "plus").foregroundColor(.gray)
+                            }
+                            .font(.caption)
+                            .modifier(ImportModelBehavior())
+                            .onAppear {
+                                NSApp.keyWindow?.standardWindowButton(.closeButton)?.isHidden = true
+                                NSApp.keyWindow?.standardWindowButton(.miniaturizeButton)?.isHidden = true
+                                NSApp.keyWindow?.standardWindowButton(.zoomButton)?.isHidden = true
+                            }
+                            .onDisappear {
+                                NSApp.keyWindow?.standardWindowButton(.closeButton)?.isHidden = false
+                                NSApp.keyWindow?.standardWindowButton(.miniaturizeButton)?.isHidden = false
+                                NSApp.keyWindow?.standardWindowButton(.zoomButton)?.isHidden = false
+                            }
+                            .keyboardShortcut("I", modifiers: [.command, .shift])
                         }
                     } label: {
                         HStack {
                             Label("Model from Hub", systemImage: "cpu").foregroundColor(.secondary)
+
                             Spacer()
                             if disclosedModel {
                                 Button {

--- a/Diffusion-macOS/Diffusion_macOSApp.swift
+++ b/Diffusion-macOS/Diffusion_macOSApp.swift
@@ -14,5 +14,17 @@ struct Diffusion_macOSApp: App {
         WindowGroup {
             ContentView()
         }
+        .commands {
+            // Add an Import Model menu item in the File menu, trigger the menu with keyboard shortcut COMMAND-SHIFT-I
+            CommandGroup(replacing: CommandGroupPlacement.newItem) {
+                Button(action: {
+                    // Using a Published variable in singleton Settings to track the status of the import panel across different parts of the app.
+                    Settings.shared.isShowingImportPanel = true
+                }) {
+                    Text("Import Model…")
+                }
+                .keyboardShortcut("I", modifiers: [.command, .shift])
+            }
+        }
     }
 }

--- a/Diffusion.xcodeproj/project.pbxproj
+++ b/Diffusion.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8CB41E9E2A4860F7006958D3 /* ImportModelBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CB41E9D2A4860F7006958D3 /* ImportModelBehavior.swift */; };
 		EB067F872992E561004D1AD9 /* HelpContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB067F862992E561004D1AD9 /* HelpContent.swift */; };
 		EB25B3D62A3A2DC4000E25A1 /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = EB25B3D52A3A2DC4000E25A1 /* StableDiffusion */; };
 		EB25B3D82A3A2DD5000E25A1 /* StableDiffusion in Frameworks */ = {isa = PBXBuildFile; productRef = EB25B3D72A3A2DD5000E25A1 /* StableDiffusion */; };
@@ -61,6 +62,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8CB41E9D2A4860F7006958D3 /* ImportModelBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportModelBehavior.swift; sourceTree = "<group>"; };
 		EB067F862992E561004D1AD9 /* HelpContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpContent.swift; sourceTree = "<group>"; };
 		EB33A51E2954E1BC00B16357 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		EB560F0329A3C20800C0F8B8 /* Capabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capabilities.swift; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 			isa = PBXGroup;
 			children = (
 				EBB5BA5929426E06003A2A5B /* Downloader.swift */,
+				8CB41E9D2A4860F7006958D3 /* ImportModelBehavior.swift */,
 				EBE3FF4B295E1EFE00E921AA /* ModelInfo.swift */,
 				EBDD7DB72976AAFE00C1C4B2 /* State.swift */,
 				EBDD7DB22973200200C1C4B2 /* Utils.swift */,
@@ -512,6 +515,7 @@
 				EBDD7DB62973206600C1C4B2 /* Downloader.swift in Sources */,
 				F155203429710B3600DC009B /* StatusView.swift in Sources */,
 				EB560F0429A3C20800C0F8B8 /* Capabilities.swift in Sources */,
+				8CB41E9E2A4860F7006958D3 /* ImportModelBehavior.swift in Sources */,
 				F15520242971093300DC009B /* Diffusion_macOSApp.swift in Sources */,
 				EBDD7DB52973201800C1C4B2 /* ModelInfo.swift in Sources */,
 				EBDD7DBD2977FFB300C1C4B2 /* GeneratedImageView.swift in Sources */,

--- a/Diffusion/Common/ImportModelBehavior.swift
+++ b/Diffusion/Common/ImportModelBehavior.swift
@@ -1,0 +1,74 @@
+//
+//  ImportModelBehavior.swift
+//  Diffusion-macOS
+//
+//  Created by Dolmere on 19/06/2023
+//  See LICENSE at https://github.com/huggingface/swift-coreml-diffusers/LICENSE
+
+
+import SwiftUI
+
+// A view modifier to add a .fileImporter import panel into a view
+struct ImportModelBehavior: ViewModifier {
+
+    @ObservedObject private var settings = Settings.shared
+
+    @State var isBadSelectionAlertShown: Bool = false
+    @State private var importPanelState: Bool = false {
+        didSet {
+            if settings.isShowingImportPanel != importPanelState {
+                settings.isShowingImportPanel = importPanelState
+            }
+        }
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .fileImporter(isPresented: $importPanelState, allowedContentTypes: [.folder, .zip]) { result in
+                do {
+                    let url = try result.get()
+                    if url.hasDirectoryPath {
+                        let fileManager = FileManager.default
+                        let contents = try fileManager.contentsOfDirectory(atPath: url.path)
+                        
+                        if contents.contains("merges.txt") && contents.contains("vocab.json") {
+                            // Folder contains the required filenames
+                            do {
+                                try fileManager.moveItem(at: url, to: Settings.shared.applicationSupportURL().appendingPathComponent("hf-diffusion-models").appendingPathComponent(url.lastPathComponent))
+                            } catch {
+                                // Error handling
+                                print("Error: \(error.localizedDescription)")
+                            }
+                        } else {
+                            // Folder does not contain the required filenames
+                            isBadSelectionAlertShown = true
+                        }
+                    } else if url.pathExtension == "zip" {
+                        do {
+                            try FileManager.default.unzipItem(at: url, to: Settings.shared.applicationSupportURL().appendingPathComponent("hf-diffusion-models"))
+                        } catch {
+                            print("error unzipping selected zip file \(error)")
+                        }
+                    } else {
+                        // Invalid selection
+                        isBadSelectionAlertShown = true
+                    }
+                    
+                } catch {
+                    // Error handling
+                    print("Error: \(error.localizedDescription)")
+                }
+            }
+            .alert(isPresented: $isBadSelectionAlertShown) {
+                Alert(
+                    title: Text("Not a model"),
+                    message: Text("The selected folder does not appear to be a model. Please select an extracted model folder or a zip compressed model file."),
+                    dismissButton: .default(Text("OK"))
+                )
+            }
+            .onReceive(settings.$isShowingImportPanel) { newValue in
+//                print("Settings.shared.isShowingImportPanel changed to \(newValue)")
+                self.importPanelState = newValue
+            }
+    }
+}

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -75,7 +75,9 @@ class GenerationContext: ObservableObject {
     }
 }
 
-class Settings {
+class Settings: ObservableObject {
+
+    @Published var isShowingImportPanel: Bool = false
     static let shared = Settings()
     
     let defaults = UserDefaults.standard
@@ -126,4 +128,25 @@ class Settings {
             return ComputeUnits(rawValue: current)
         }
     }
+    
+    public func applicationSupportURL() -> URL {
+        let fileManager = FileManager.default
+        guard let appSupportURL = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            // To ensure we don't return an optional - if the user domain application support cannot be accessed use the top level application support directory
+            return URL.applicationSupportDirectory
+        }
+
+        let appBundleIdentifier = Bundle.main.bundleIdentifier ?? ""
+        let appDirectoryURL = appSupportURL.appendingPathComponent(appBundleIdentifier)
+
+        do {
+            // Create the application support directory if it doesn't exist
+            try fileManager.createDirectory(at: appDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+            return appDirectoryURL
+        } catch {
+            print("Error creating application support directory: \(error)")
+            return fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        }
+    }
+
 }


### PR DESCRIPTION
macOS only** (For iOS it would be good to open from Files, Dropbox, and other compatible file sources.)

To trigger this new feature you can open the File menu and select Import Model, you can press Command-Shift-I, or you can press the [+] button next to the list of models.

Once triggered a file browser will show to allow the user to navigate to a folder with a model they downloaded from the Hub / internet.
The user can select a folder or a .zip file. One selected the code will validate whether key necessary files and resources exist inside the selected folder or blindly process a zip file.

If the folder contains the key resources then it copies the folder to the models folder. If it's a zip file that file is extracted into the models folder.

After extracting a zip the contents are now checked for key resources. If missing the extracted folder is deleted and the user is alerted to the import failing.

This way we make an attempt to prevent corrupted entries from appearing in the UI, at least from the basic user who doesn't modify their models folder contents manually.
