### PR TITLE
Uint32 Seed

### DIFF
--- a/Diffusion-macOS/ControlsView.swift
+++ b/Diffusion-macOS/ControlsView.swift
@@ -10,6 +10,7 @@ import Combine
 import SwiftUI
 import CompactSlider
 
+/// Track a StableDiffusion Pipeline's readiness. This include actively downloading from the internet, uncompressing the downloaded zip file, actively loading into memory, ready to use or an Error state.
 enum PipelineState {
     case downloading(Double)
     case uncompressing
@@ -80,21 +81,28 @@ struct ControlsView: View {
 
     let maxSeed: UInt32 = UInt32.max
     private var textFieldLabelSeed: String { generation.seed < 1 ? "Random Seed" : "Seed" }
-
-    func updateSafetyCheckerState() {
+    
+    var modelFilename: String? {
+        guard let pipelineLoader = pipelineLoader else { return nil }
+        let selectedURL = pipelineLoader.compiledURL
+        guard FileManager.default.fileExists(atPath: selectedURL.path) else { return nil }
+        return selectedURL.path
+    }
+    
+    fileprivate func updateSafetyCheckerState() {
         mustShowSafetyCheckerDisclaimer = generation.disableSafety && !Settings.shared.safetyCheckerDisclaimerShown
     }
     
-    func updateComputeUnitsState() {
+    fileprivate func updateComputeUnitsState() {
         Settings.shared.userSelectedComputeUnits = generation.computeUnits
         modelDidChange(model: Settings.shared.currentModel)
     }
     
-    func resetComputeUnitsState() {
+    fileprivate func resetComputeUnitsState() {
         generation.computeUnits = Settings.shared.userSelectedComputeUnits ?? ModelInfo.defaultComputeUnits
     }
 
-    func modelDidChange(model: ModelInfo) {
+    fileprivate func modelDidChange(model: ModelInfo) {
         guard pipelineLoader?.model != model || pipelineLoader?.computeUnits != generation.computeUnits else {
             print("Reusing same model \(model) with units \(generation.computeUnits)")
             return
@@ -133,24 +141,17 @@ struct ControlsView: View {
         }
     }
     
-    func isModelDownloaded(_ model: ModelInfo, computeUnits: ComputeUnits? = nil) -> Bool {
+    fileprivate func isModelDownloaded(_ model: ModelInfo, computeUnits: ComputeUnits? = nil) -> Bool {
         PipelineLoader(model: model, computeUnits: computeUnits ?? generation.computeUnits).ready
     }
     
-    func modelLabel(_ model: ModelInfo) -> Text {
+    fileprivate func modelLabel(_ model: ModelInfo) -> Text {
         let downloaded = isModelDownloaded(model)
         let prefix = downloaded ? "● " : "◌ "  //"○ "
         return Text(prefix).foregroundColor(downloaded ? .accentColor : .secondary) + Text(model.modelVersion)
     }
     
-    var modelFilename: String? {
-        guard let pipelineLoader = pipelineLoader else { return nil }
-        let selectedURL = pipelineLoader.compiledURL
-        guard FileManager.default.fileExists(atPath: selectedURL.path) else { return nil }
-        return selectedURL.path
-    }
-    
-    private func prompts() -> some View {
+    fileprivate func prompts() -> some View {
         VStack {
             Spacer()
             PromptTextField(text: $generation.positivePrompt, isPositivePrompt: true, model: $model)
@@ -183,6 +184,7 @@ struct ControlsView: View {
                         }
                         .onChange(of: model) { selection in
                             guard selection != revealOption else {
+                                // The reveal option has been requested - open the models folder in Finder
                                 NSWorkspace.shared.selectFile(modelFilename, inFileViewerRootedAtPath: PipelineLoader.models.path)
                                 model = Settings.shared.currentModel.modelVersion
                                 return
@@ -453,6 +455,4 @@ struct ControlsView: View {
             Stepper("", value: $generation.seed, in: 0...UInt32.max)
         }
     }
-
 }
-

--- a/Diffusion-macOS/ControlsView.swift
+++ b/Diffusion-macOS/ControlsView.swift
@@ -425,7 +425,7 @@ struct ControlsView: View {
     fileprivate func discloseSeedContent() -> some View {
         let seedBinding = Binding<String>(
             get: {
-                generation.seed < 1 ? "" : String(generation.seed)
+                String(generation.seed)
             },
             set: { newValue in
                 if let seed = UInt32(newValue) {

--- a/Diffusion-macOS/ControlsView.swift
+++ b/Diffusion-macOS/ControlsView.swift
@@ -288,6 +288,7 @@ struct ControlsView: View {
                                         
                     DisclosureGroup(isExpanded: $disclosedSeed) {
                         discloseSeedContent()
+                            .padding(.leading, 10)
                     } label: {
                         HStack {
                             Label(textFieldLabelSeed, systemImage: "leaf").foregroundColor(.secondary)

--- a/Diffusion-macOS/HelpContent.swift
+++ b/Diffusion-macOS/HelpContent.swift
@@ -119,7 +119,7 @@ func seedHelp(_ showing: Binding<Bool>) -> some View {
          Next, maybe add a negative prompt or tweak the prompt slightly, and see how the result changes. \
          Rinse and repeat until you are satisfied, or select a new seed to start over.
 
-         If you select -1, a random seed will be chosen for you.
+         Set the value to 0 for a random seed to be chosen for you.
          """
     return helpContent(title: "Generation Seed", description: description, showing: showing)
 }

--- a/Diffusion-macOS/StatusView.swift
+++ b/Diffusion-macOS/StatusView.swift
@@ -87,10 +87,10 @@ struct StatusView: View {
                 let intervalString = String(format: "Time: %.1fs", interval ?? 0)
                 Text(intervalString)
                 Spacer()
-                if generation.seed != Double(lastSeed) {
+                if generation.seed != UInt32(lastSeed) {
                     Text("Seed: \(lastSeed)")
                     Button("Set") {
-                        generation.seed = Double(lastSeed)
+                        generation.seed = UInt32(lastSeed)
                     }
                 }
             }.frame(maxHeight: 25)

--- a/Diffusion-macOS/StatusView.swift
+++ b/Diffusion-macOS/StatusView.swift
@@ -90,7 +90,7 @@ struct StatusView: View {
                 if generation.seed != lastSeed {
                     Text("Seed: \(lastSeed)")
                     Button("Set") {
-                        generation.seed = UInt32(lastSeed)
+                        generation.seed = lastSeed
                     }
                 }
             }.frame(maxHeight: 25)

--- a/Diffusion-macOS/StatusView.swift
+++ b/Diffusion-macOS/StatusView.swift
@@ -88,7 +88,8 @@ struct StatusView: View {
                 Text(intervalString)
                 Spacer()
                 if generation.seed != lastSeed {
-                    Text("Seed: \(lastSeed)")
+                    
+                    Text(String("Seed: \(formatLargeNumber(lastSeed))"))
                     Button("Set") {
                         generation.seed = lastSeed
                     }

--- a/Diffusion-macOS/StatusView.swift
+++ b/Diffusion-macOS/StatusView.swift
@@ -87,7 +87,7 @@ struct StatusView: View {
                 let intervalString = String(format: "Time: %.1fs", interval ?? 0)
                 Text(intervalString)
                 Spacer()
-                if generation.seed != UInt32(lastSeed) {
+                if generation.seed != lastSeed {
                     Text("Seed: \(lastSeed)")
                     Button("Set") {
                         generation.seed = UInt32(lastSeed)

--- a/Diffusion/Common/Pipeline/Pipeline.swift
+++ b/Diffusion/Common/Pipeline/Pipeline.swift
@@ -45,14 +45,14 @@ class Pipeline {
         negativePrompt: String = "",
         scheduler: StableDiffusionScheduler,
         numInferenceSteps stepCount: Int = 50,
-        seed: UInt32? = nil,
+        seed: UInt32 = 0,
         guidanceScale: Float = 7.5,
         disableSafety: Bool = false
     ) throws -> GenerationResult {
         let beginDate = Date()
         canceled = false
         print("Generating...")
-        let theSeed = seed ?? UInt32.random(in: 0...maxSeed)
+        let theSeed = seed > 1 ? seed : UInt32.random(in: 1...maxSeed)
         let sampleTimer = SampleTimer()
         sampleTimer.start()
         

--- a/Diffusion/Common/Pipeline/Pipeline.swift
+++ b/Diffusion/Common/Pipeline/Pipeline.swift
@@ -69,7 +69,7 @@ class Pipeline {
     ) throws -> GenerationResult {
         let beginDate = Date()
         canceled = false
-        let theSeed = seed > 1 ? seed : UInt32.random(in: 1...maxSeed)
+        let theSeed = seed > 0 ? seed : UInt32.random(in: 1...maxSeed)
         let sampleTimer = SampleTimer()
         sampleTimer.start()
         

--- a/Diffusion/Common/Pipeline/Pipeline.swift
+++ b/Diffusion/Common/Pipeline/Pipeline.swift
@@ -69,7 +69,6 @@ class Pipeline {
     ) throws -> GenerationResult {
         let beginDate = Date()
         canceled = false
-//        print("Generating...")
         let theSeed = seed > 1 ? seed : UInt32.random(in: 1...maxSeed)
         let sampleTimer = SampleTimer()
         sampleTimer.start()

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -17,7 +17,6 @@ let DEFAULT_PROMPT = "Labrador in the style of Vermeer"
 enum GenerationState {
     case startup
     case running(StableDiffusionProgress?)
-    //complete(positivePrompt, optional generated image, seed used to create it, how long it took to generate)
     case complete(String, CGImage?, UInt32, TimeInterval?)
     case userCanceled
     case failed(Error)

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -78,7 +78,7 @@ class GenerationContext: ObservableObject {
             negativePrompt: negativePrompt,
             scheduler: scheduler,
             numInferenceSteps: Int(steps),
-            seed: UInt32(seed ?? 0),
+            seed: seed,
             numPreviews: Int(previews),
             guidanceScale: Float(guidanceScale),
             disableSafety: disableSafety

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -17,6 +17,7 @@ let DEFAULT_PROMPT = "Labrador in the style of Vermeer"
 enum GenerationState {
     case startup
     case running(StableDiffusionProgress?)
+    //complete(positivePrompt, optional generated image, seed used to create it, how long it took to generate)
     case complete(String, CGImage?, UInt32, TimeInterval?)
     case userCanceled
     case failed(Error)
@@ -48,7 +49,7 @@ class GenerationContext: ObservableObject {
     // FIXME: Double to support the slider component
     @Published var steps = 25.0
     @Published var numImages = 1.0
-    @Published var seed = -1.0
+    @Published var seed = UInt32(0)
     @Published var guidanceScale = 7.5
     @Published var disableSafety = false
     
@@ -58,13 +59,13 @@ class GenerationContext: ObservableObject {
 
     func generate() async throws -> GenerationResult {
         guard let pipeline = pipeline else { throw "No pipeline" }
-        let seed = self.seed >= 0 ? UInt32(self.seed) : nil
+        let seed = self.seed > 0 ? UInt32(self.seed) : nil
         return try pipeline.generate(
             prompt: positivePrompt,
             negativePrompt: negativePrompt,
             scheduler: scheduler,
             numInferenceSteps: Int(steps),
-            seed: seed,
+            seed: UInt32(seed ?? 0),
             guidanceScale: Float(guidanceScale),
             disableSafety: disableSafety
         )

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -72,7 +72,6 @@ class GenerationContext: ObservableObject {
 
     func generate() async throws -> GenerationResult {
         guard let pipeline = pipeline else { throw "No pipeline" }
-        let seed = self.seed > 0 ? UInt32(self.seed) : nil
         return try pipeline.generate(
             prompt: positivePrompt,
             negativePrompt: negativePrompt,

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -50,7 +50,7 @@ class GenerationContext: ObservableObject {
     // FIXME: Double to support the slider component
     @Published var steps = 25.0
     @Published var numImages = 1.0
-    @Published var seed = UInt32(0)
+    @Published var seed: UInt32 = 0
     @Published var guidanceScale = 7.5
     @Published var previews = 5.0
     @Published var disableSafety = false

--- a/Diffusion/Common/Utils.swift
+++ b/Diffusion/Common/Utils.swift
@@ -43,3 +43,38 @@ func previewIndices(_ numInferenceSteps: Int, _ numPreviews: Int) -> [Bool] {
 
     return previewArray
 }
+
+extension Double {
+    func reduceScale(to places: Int) -> Double {
+        let multiplier = pow(10, Double(places))
+        let newDecimal = multiplier * self // move the decimal right
+        let truncated = Double(Int(newDecimal)) // drop the fraction
+        let originalDecimal = truncated / multiplier // move the decimal back
+        return originalDecimal
+    }
+}
+
+func formatLargeNumber(_ n: UInt32) -> String {
+    let num = abs(Double(n))
+
+    switch num {
+    case 1_000_000_000...:
+        var formatted = num / 1_000_000_000
+        formatted = formatted.reduceScale(to: 3)
+        return "\(formatted)B"
+
+    case 1_000_000...:
+        var formatted = num / 1_000_000
+        formatted = formatted.reduceScale(to: 3)
+        return "\(formatted)M"
+
+    case 1_000...:
+        return "\(n)"
+
+    case 0...:
+        return "\(n)"
+
+    default:
+        return "\(n)"
+    }
+}


### PR DESCRIPTION
Justification: The seed internally is changed between different number types with wildly different max values. This PR normalizes all of them to UInt32.

Earlier @pcuenca commented that the reason for the lower precision use of Double was to support the CompactSlider component and make it easier for a user to select a number.

In this submission the CompactSlider component has been swapped for a TextField.

[Feature extracted from larger PR #59 https://github.com/huggingface/swift-coreml-diffusers/pull/59]