### PR TITLE
Preview progress images

### DIFF
--- a/Diffusion-macOS/ControlsView.swift
+++ b/Diffusion-macOS/ControlsView.swift
@@ -253,7 +253,7 @@ struct ControlsView: View {
                     }
 
                     DisclosureGroup(isExpanded: $disclosedSteps) {
-                        CompactSlider(value: $generation.steps, in: 0...150, step: 5) {
+                        CompactSlider(value: $generation.steps, in: 1...150, step: 1) {
                             Text("Steps")
                             Spacer()
                             Text("\(Int(generation.steps))")

--- a/Diffusion-macOS/ControlsView.swift
+++ b/Diffusion-macOS/ControlsView.swift
@@ -55,6 +55,7 @@ struct ControlsView: View {
     @State private var disclosedPrompt = true
     @State private var disclosedGuidance = false
     @State private var disclosedSteps = false
+    @State private var disclosedPreview = false
     @State private var disclosedSeed = false
     @State private var disclosedAdvanced = false
 
@@ -71,6 +72,7 @@ struct ControlsView: View {
     @State private var showPromptsHelp = false
     @State private var showGuidanceHelp = false
     @State private var showStepsHelp = false
+    @State private var showPreviewHelp = false
     @State private var showSeedHelp = false
     @State private var showAdvancedHelp = false
 
@@ -277,7 +279,33 @@ struct ControlsView: View {
                             }
                         }.foregroundColor(.secondary)
                     }
-                                        
+
+                    DisclosureGroup(isExpanded: $disclosedPreview) {
+                        CompactSlider(value: $generation.previews, in: 0...25, step: 1) {
+                            Text("Previews")
+                            Spacer()
+                            Text("\(Int(generation.previews))")
+                        }.padding(.leading, 10)
+                    } label: {
+                        HStack {
+                            Label("Preview count", systemImage: "eye.square").foregroundColor(.secondary)
+                            Spacer()
+                            if disclosedPreview {
+                                Button {
+                                    showPreviewHelp.toggle()
+                                } label: {
+                                    Image(systemName: "info.circle")
+                                }
+                                .buttonStyle(.plain)
+                                .popover(isPresented: $showPreviewHelp, arrowEdge: .trailing) {
+                                    previewHelp($showPreviewHelp)
+                                }
+                            } else {
+                                Text("\(Int(generation.previews))")
+                            }
+                        }.foregroundColor(.secondary)
+                    }
+
                     DisclosureGroup(isExpanded: $disclosedSeed) {
                         let sliderLabel = generation.seed < 0 ? "Random Seed" : "Seed"
                         CompactSlider(value: $generation.seed, in: -1...Double(maxSeed), step: 1) {
@@ -304,7 +332,7 @@ struct ControlsView: View {
                             }
                         }.foregroundColor(.secondary)
                     }
-                    
+
                     if Capabilities.hasANE {
                         Divider()
                         DisclosureGroup(isExpanded: $disclosedAdvanced) {

--- a/Diffusion-macOS/GeneratedImageView.swift
+++ b/Diffusion-macOS/GeneratedImageView.swift
@@ -10,34 +10,37 @@ import SwiftUI
 
 struct GeneratedImageView: View {
     @EnvironmentObject var generation: GenerationContext
-    
+
     var body: some View {
         switch generation.state {
         case .startup: return AnyView(Image("placeholder").resizable())
         case .running(let progress):
-            guard let progress = progress, progress.stepCount > 0, progress.currentImages.count > 0 else {
+            guard let progress = progress, progress.stepCount > 0 else {
                 // The first time it takes a little bit before generation starts
                 return AnyView(ProgressView())
             }
-            guard let theImage = progress.currentImages.first, let safeImage = theImage else {
-                return AnyView(Image(systemName: "exclamationmark.triangle").resizable())
-            }
+
             let step = Int(progress.step) + 1
             let fraction = Double(step) / Double(progress.stepCount)
             let label = "Step \(step) of \(progress.stepCount)"
+
             return AnyView(VStack {
-                Image(safeImage, scale: 1, label: Text("generated"))
-                    .resizable()
-                    .clipShape(RoundedRectangle(cornerRadius: 20))
-                    .contextMenu {
-                        Button {
-                            NSPasteboard.general.clearContents()
-                            let nsimage = NSImage(cgImage: safeImage, size: NSSize(width: safeImage.width, height: safeImage.height))
-                            NSPasteboard.general.writeObjects([nsimage])
-                        } label: {
-                            Text("Copy Photo")
-                        }
+                Group {
+                    if let safeImage = generation.previewImage {
+                        Image(safeImage, scale: 1, label: Text("generated"))
+                            .resizable()
+                            .clipShape(RoundedRectangle(cornerRadius: 20))
+                            .contextMenu {
+                                Button {
+                                    NSPasteboard.general.clearContents()
+                                    let nsimage = NSImage(cgImage: safeImage, size: NSSize(width: safeImage.width, height: safeImage.height))
+                                    NSPasteboard.general.writeObjects([nsimage])
+                                } label: {
+                                    Text("Copy Photo")
+                                }
+                            }
                     }
+                }
                 HStack {
                     ProgressView(label, value: fraction, total: 1).padding()
                     Button {
@@ -52,7 +55,7 @@ struct GeneratedImageView: View {
             guard let theImage = image else {
                 return AnyView(Image(systemName: "exclamationmark.triangle").resizable())
             }
-                              
+            
             return AnyView(
                     Image(theImage, scale: 1, label: Text("generated"))
                     .resizable()

--- a/Diffusion-macOS/GeneratedImageView.swift
+++ b/Diffusion-macOS/GeneratedImageView.swift
@@ -15,21 +15,38 @@ struct GeneratedImageView: View {
         switch generation.state {
         case .startup: return AnyView(Image("placeholder").resizable())
         case .running(let progress):
-            guard let progress = progress, progress.stepCount > 0 else {
+            guard let progress = progress, progress.stepCount > 0, progress.currentImages.count > 0 else {
                 // The first time it takes a little bit before generation starts
                 return AnyView(ProgressView())
+            }
+            guard let theImage = progress.currentImages.first, let safeImage = theImage else {
+                return AnyView(Image(systemName: "exclamationmark.triangle").resizable())
             }
             let step = Int(progress.step) + 1
             let fraction = Double(step) / Double(progress.stepCount)
             let label = "Step \(step) of \(progress.stepCount)"
-            return AnyView(HStack {
-                ProgressView(label, value: fraction, total: 1).padding()
-                Button {
-                    generation.cancelGeneration()
-                } label: {
-                    Image(systemName: "x.circle.fill").foregroundColor(.gray)
+            return AnyView(VStack {
+                Image(safeImage, scale: 1, label: Text("generated"))
+                    .resizable()
+                    .clipShape(RoundedRectangle(cornerRadius: 20))
+                    .contextMenu {
+                        Button {
+                            NSPasteboard.general.clearContents()
+                            let nsimage = NSImage(cgImage: safeImage, size: NSSize(width: safeImage.width, height: safeImage.height))
+                            NSPasteboard.general.writeObjects([nsimage])
+                        } label: {
+                            Text("Copy Photo")
+                        }
+                    }
+                HStack {
+                    ProgressView(label, value: fraction, total: 1).padding()
+                    Button {
+                        generation.cancelGeneration()
+                    } label: {
+                        Image(systemName: "x.circle.fill").foregroundColor(.gray)
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
             })
         case .complete(_, let image, _, _):
             guard let theImage = image else {

--- a/Diffusion-macOS/GeneratedImageView.swift
+++ b/Diffusion-macOS/GeneratedImageView.swift
@@ -29,16 +29,7 @@ struct GeneratedImageView: View {
                     if let safeImage = generation.previewImage {
                         Image(safeImage, scale: 1, label: Text("generated"))
                             .resizable()
-                            .clipShape(RoundedRectangle(cornerRadius: 20))
-                            .contextMenu {
-                                Button {
-                                    NSPasteboard.general.clearContents()
-                                    let nsimage = NSImage(cgImage: safeImage, size: NSSize(width: safeImage.width, height: safeImage.height))
-                                    NSPasteboard.general.writeObjects([nsimage])
-                                } label: {
-                                    Text("Copy Photo")
-                                }
-                            }
+                            .clipShape(RoundedRectangle(cornerRadius: 20))                        
                     }
                 }
                 HStack {

--- a/Diffusion-macOS/HelpContent.swift
+++ b/Diffusion-macOS/HelpContent.swift
@@ -119,9 +119,10 @@ func previewHelp(_ showing: Binding<Bool>) -> some View {
          the generation process is progressing.
 
          However, computing each preview consumes computation power, and can slow down \
-         the overall process as the number increases.
+         the overall process. If the process is too slow you can reduce the preview count \
+         which will result in less visibility of the generation process.
 
-         Typically, a balance between speed and variety is best.
+         You can try different values to see what works best for your hardware.
          """
     return helpContent(title: "Preview Count", description: description, showing: showing)
 }

--- a/Diffusion-macOS/HelpContent.swift
+++ b/Diffusion-macOS/HelpContent.swift
@@ -113,16 +113,18 @@ func stepsHelp(_ showing: Binding<Bool>) -> some View {
 func previewHelp(_ showing: Binding<Bool>) -> some View {
     let description =
          """
-         This number controls the how many previews to display throughout the image generation.
+         This number controls how many previews to display throughout the image generation process.
 
-         A higher number of previews can be useful if you want more visibility into how \
-         the generation process is progressing.
+         Using more previews can be useful if you want more visibility into how \
+         generation is progressing.
 
-         However, computing each preview consumes computation power, and can slow down \
-         the overall process. If the process is too slow you can reduce the preview count \
-         which will result in less visibility of the generation process.
+         However, computing each preview takes some time and can slow down \
+         generation. If the process is too slow you can reduce the preview count, \
+         which will result in less visibility of intermediate steps during generation.
 
          You can try different values to see what works best for your hardware.
+
+         For the absolute fastest generation times, use 0 previews.
          """
     return helpContent(title: "Preview Count", description: description, showing: showing)
 }

--- a/Diffusion-macOS/HelpContent.swift
+++ b/Diffusion-macOS/HelpContent.swift
@@ -110,6 +110,22 @@ func stepsHelp(_ showing: Binding<Bool>) -> some View {
     return helpContent(title: "Inference Steps", description: description, showing: showing)
 }
 
+func previewHelp(_ showing: Binding<Bool>) -> some View {
+    let description =
+         """
+         This number controls the how many previews to display throughout the image generation.
+
+         A higher number of previews can be useful if you want more visibility into how \
+         the generation process is progressing.
+
+         However, computing each preview consumes computation power, and can slow down \
+         the overall process as the number increases.
+
+         Typically, a balance between speed and variety is best.
+         """
+    return helpContent(title: "Preview Count", description: description, showing: showing)
+}
+
 func seedHelp(_ showing: Binding<Bool>) -> some View {
     let description =
          """

--- a/Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Diffusion.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/buh/CompactSlider.git",
       "state" : {
         "branch" : "main",
-        "revision" : "3cb37fb7385913835b6844c6af2680c64000dcd2"
+        "revision" : "6d591a76caecd583ad69fbcd06f2fb83135318c0"
       }
     },
     {
@@ -15,7 +15,7 @@
       "location" : "https://github.com/apple/ml-stable-diffusion",
       "state" : {
         "branch" : "main",
-        "revision" : "48f07f24891155a14c51dd835bba7371bdf32d0e"
+        "revision" : "b61c9aea05370d4bc06fce2dc00a002b21f13da5"
       }
     },
     {

--- a/Diffusion/Common/Pipeline/Pipeline.swift
+++ b/Diffusion/Common/Pipeline/Pipeline.swift
@@ -81,6 +81,7 @@ class Pipeline {
         config.guidanceScale = guidanceScale
         config.disableSafety = disableSafety
         config.schedulerType = scheduler
+        config.useDenoisedIntermediates = true
 
         // Evenly distribute previews based on inference steps
         let previewIndices = previewIndices(stepCount, previewCount)

--- a/Diffusion/Common/Pipeline/Pipeline.swift
+++ b/Diffusion/Common/Pipeline/Pipeline.swift
@@ -40,7 +40,7 @@ struct GenerationResult {
 }
 
 class Pipeline {
-    var pipeline: StableDiffusionPipeline
+    let pipeline: StableDiffusionPipeline
     let maxSeed: UInt32
     
     var progress: StableDiffusionProgress? = nil {

--- a/Diffusion/Common/Pipeline/Pipeline.swift
+++ b/Diffusion/Common/Pipeline/Pipeline.swift
@@ -12,7 +12,24 @@ import Combine
 
 import StableDiffusion
 
-typealias StableDiffusionProgress = StableDiffusionPipeline.Progress
+struct StableDiffusionProgress {
+    var progress: StableDiffusionPipeline.Progress
+
+    var step: Int { progress.step }
+    var stepCount: Int { progress.stepCount }
+
+    var currentImages: [CGImage?]
+
+    init(progress: StableDiffusionPipeline.Progress, previewIndices: [Bool]) {
+        self.progress = progress
+        self.currentImages = [nil]
+
+        // Since currentImages is a computed property, only access the preview image if necessary
+        if progress.step < previewIndices.count, previewIndices[progress.step] {
+            self.currentImages = progress.currentImages
+        }
+    }
+}
 
 struct GenerationResult {
     var image: CGImage?
@@ -23,7 +40,7 @@ struct GenerationResult {
 }
 
 class Pipeline {
-    let pipeline: StableDiffusionPipeline
+    var pipeline: StableDiffusionPipeline
     let maxSeed: UInt32
     
     var progress: StableDiffusionProgress? = nil {
@@ -45,6 +62,7 @@ class Pipeline {
         negativePrompt: String = "",
         scheduler: StableDiffusionScheduler,
         numInferenceSteps stepCount: Int = 50,
+        numPreviews previewCount: Int = 5,
         seed: UInt32? = nil,
         guidanceScale: Float = 7.5,
         disableSafety: Bool = false
@@ -63,10 +81,15 @@ class Pipeline {
         config.guidanceScale = guidanceScale
         config.disableSafety = disableSafety
         config.schedulerType = scheduler
-        
+
+        // Evenly distribute previews based on inference steps
+        let previewIndices = previewIndices(stepCount, previewCount)
+
         let images = try pipeline.generateImages(configuration: config) { progress in
             sampleTimer.stop()
-            handleProgress(progress, sampleTimer: sampleTimer)
+            handleProgress(StableDiffusionProgress(progress: progress,
+                                                   previewIndices: previewIndices),
+                           sampleTimer: sampleTimer)
             if progress.stepCount != progress.step {
                 sampleTimer.start()
             }
@@ -80,7 +103,7 @@ class Pipeline {
         return GenerationResult(image: image, lastSeed: theSeed, interval: interval, userCanceled: canceled, itsPerSecond: 1.0/sampleTimer.median)
     }
 
-    func handleProgress(_ progress: StableDiffusionPipeline.Progress, sampleTimer: SampleTimer) {
+    func handleProgress(_ progress: StableDiffusionProgress, sampleTimer: SampleTimer) {
         self.progress = progress
     }
         

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -35,6 +35,7 @@ class GenerationContext: ObservableObject {
                     .receive(on: DispatchQueue.main)
                     .sink { progress in
                         guard let progress = progress else { return }
+                        self.updatePreviewIfNeeded(progress)
                         self.state = .running(progress)
                     }
             }
@@ -50,11 +51,22 @@ class GenerationContext: ObservableObject {
     @Published var numImages = 1.0
     @Published var seed = -1.0
     @Published var guidanceScale = 7.5
+    @Published var previews = 5.0
     @Published var disableSafety = false
-    
+    @Published var previewImage: CGImage? = nil
+
     @Published var computeUnits: ComputeUnits = Settings.shared.userSelectedComputeUnits ?? ModelInfo.defaultComputeUnits
 
     private var progressSubscriber: Cancellable?
+
+    private func updatePreviewIfNeeded(_ progress: StableDiffusionProgress) {
+        if previews > 0, let newImage = progress.currentImages.first, newImage != nil {
+            previewImage = newImage
+        } else if previews == 0 {
+            // Previews disabled
+            previewImage = nil
+        }
+    }
 
     func generate() async throws -> GenerationResult {
         guard let pipeline = pipeline else { throw "No pipeline" }
@@ -64,6 +76,7 @@ class GenerationContext: ObservableObject {
             negativePrompt: negativePrompt,
             scheduler: scheduler,
             numInferenceSteps: Int(steps),
+            numPreviews: Int(previews),
             seed: seed,
             guidanceScale: Float(guidanceScale),
             disableSafety: disableSafety

--- a/Diffusion/Common/State.swift
+++ b/Diffusion/Common/State.swift
@@ -60,11 +60,12 @@ class GenerationContext: ObservableObject {
     private var progressSubscriber: Cancellable?
 
     private func updatePreviewIfNeeded(_ progress: StableDiffusionProgress) {
+        if previews == 0 || progress.step == 0 {
+            previewImage = nil
+        }
+
         if previews > 0, let newImage = progress.currentImages.first, newImage != nil {
             previewImage = newImage
-        } else if previews == 0 {
-            // Previews disabled
-            previewImage = nil
         }
     }
 

--- a/Diffusion/Common/Utils.swift
+++ b/Diffusion/Common/Utils.swift
@@ -26,7 +26,7 @@ extension Double {
 func previewIndices(_ numInferenceSteps: Int, _ numPreviews: Int) -> [Bool] {
     // Ensure valid parameters
     guard numInferenceSteps > 0, numPreviews > 0 else {
-        return [Bool](repeating: false, count: numInferenceSteps) // If parameters are not valid, return an array with only `false` values
+        return [Bool](repeating: false, count: numInferenceSteps)
     }
 
     // Compute the ideal (floating-point) step size, which represents the average number of steps between previews
@@ -39,19 +39,7 @@ func previewIndices(_ numInferenceSteps: Int, _ numPreviews: Int) -> [Bool] {
     })
     
     // Construct an array of booleans where each value indicates whether or not a preview should be made at that step.
-    // For each step in the total number of steps, we check if it is in our set of preview indices, resulting in `true` or `false`.
-    var previewArray = [Bool]()
+    let previewArray = (0..<numInferenceSteps).map { previewIndices.contains($0) }
 
-    // For each step in the total number of steps
-    for step in 0..<numInferenceSteps {
-        // Check if the current step is in our set of preview indices
-        // If it is, append `true` to our array, otherwise append `false`
-        if previewIndices.contains(step) {
-            previewArray.append(true)
-        } else {
-            previewArray.append(false)
-        }
-    }
-    
     return previewArray
 }

--- a/Diffusion/Common/Utils.swift
+++ b/Diffusion/Common/Utils.swift
@@ -15,3 +15,43 @@ extension Double {
         return String(format: "\(format)", self)
     }
 }
+
+/// Returns an array of booleans that indicates at which steps a preview should be generated.
+///
+/// - Parameters:
+///   - numInferenceSteps: The total number of inference steps.
+///   - numPreviews: The desired number of previews.
+///
+/// - Returns: An array of booleans of size `numInferenceSteps`, where `true` values represent steps at which a preview should be made.
+func previewIndices(_ numInferenceSteps: Int, _ numPreviews: Int) -> [Bool] {
+    // Ensure valid parameters
+    guard numInferenceSteps > 0, numPreviews > 0 else {
+        return [Bool](repeating: false, count: numInferenceSteps) // If parameters are not valid, return an array with only `false` values
+    }
+
+    // Compute the ideal (floating-point) step size, which represents the average number of steps between previews
+    let idealStep = Double(numInferenceSteps) / Double(numPreviews)
+
+    // Compute the actual steps at which previews should be made. For each preview, we multiply the ideal step size by the preview number, and round to the nearest integer.
+    // The result is converted to a `Set` for fast membership tests.
+    let previewIndices: Set<Int> = Set((0..<numPreviews).map { previewIndex in
+        return Int(round(Double(previewIndex) * idealStep))
+    })
+    
+    // Construct an array of booleans where each value indicates whether or not a preview should be made at that step.
+    // For each step in the total number of steps, we check if it is in our set of preview indices, resulting in `true` or `false`.
+    var previewArray = [Bool]()
+
+    // For each step in the total number of steps
+    for step in 0..<numInferenceSteps {
+        // Check if the current step is in our set of preview indices
+        // If it is, append `true` to our array, otherwise append `false`
+        if previewIndices.contains(step) {
+            previewArray.append(true)
+        } else {
+            previewArray.append(false)
+        }
+    }
+    
+    return previewArray
+}

--- a/Diffusion/Views/TextToImage.swift
+++ b/Diffusion/Views/TextToImage.swift
@@ -62,16 +62,18 @@ struct ImageWithPlaceholder: View {
                 // The first time it takes a little bit before generation starts
                 return AnyView(ProgressView())
             }
-            guard let theImage = progress.currentImages.first, let safeImage = theImage else {
-                return AnyView(Image(systemName: "exclamationmark.triangle").resizable())
-            }
+
             let step = Int(progress.step) + 1
             let fraction = Double(step) / Double(progress.stepCount)
             let label = "Step \(step) of \(progress.stepCount)"
             return AnyView(VStack {
-                Image(safeImage, scale: 1, label: Text("generated"))
-                    .resizable()
-                    .clipShape(RoundedRectangle(cornerRadius: 20))
+                Group {
+                    if let theImage = progress.currentImages.first, let safeImage = theImage {
+                        Image(safeImage, scale: 1, label: Text("generated"))
+                            .resizable()
+                            .clipShape(RoundedRectangle(cornerRadius: 20))
+                    }
+                }
                 ProgressView(label, value: fraction, total: 1).padding()
             })
         case .complete(let lastPrompt, let image, _, let interval):

--- a/Diffusion/Views/TextToImage.swift
+++ b/Diffusion/Views/TextToImage.swift
@@ -62,10 +62,18 @@ struct ImageWithPlaceholder: View {
                 // The first time it takes a little bit before generation starts
                 return AnyView(ProgressView())
             }
+            guard let theImage = progress.currentImages.first, let safeImage = theImage else {
+                return AnyView(Image(systemName: "exclamationmark.triangle").resizable())
+            }
             let step = Int(progress.step) + 1
             let fraction = Double(step) / Double(progress.stepCount)
             let label = "Step \(step) of \(progress.stepCount)"
-            return AnyView(ProgressView(label, value: fraction, total: 1).padding())
+            return AnyView(VStack {
+                Image(safeImage, scale: 1, label: Text("generated"))
+                    .resizable()
+                    .clipShape(RoundedRectangle(cornerRadius: 20))
+                ProgressView(label, value: fraction, total: 1).padding()
+            })
         case .complete(let lastPrompt, let image, _, let interval):
             guard let theImage = image else {
                 return AnyView(Image(systemName: "exclamationmark.triangle").resizable())

--- a/Diffusion/Views/TextToImage.swift
+++ b/Diffusion/Views/TextToImage.swift
@@ -52,6 +52,7 @@ struct ShareButtons: View {
 }
 
 struct ImageWithPlaceholder: View {
+    @EnvironmentObject var generation: GenerationContext
     var state: Binding<GenerationState>
         
     var body: some View {
@@ -68,7 +69,7 @@ struct ImageWithPlaceholder: View {
             let label = "Step \(step) of \(progress.stepCount)"
             return AnyView(VStack {
                 Group {
-                    if let theImage = progress.currentImages.first, let safeImage = theImage {
+                    if let safeImage = generation.previewImage {
                         Image(safeImage, scale: 1, label: Text("generated"))
                             .resizable()
                             .clipShape(RoundedRectangle(cornerRadius: 20))
@@ -139,5 +140,6 @@ struct TextToImage: View {
             Spacer()
         }
         .padding()
+        .environmentObject(generation)
     }
 }


### PR DESCRIPTION
This PR adds a preview image while generation is in progress, giving a nice feel for how the denoising process is going in real-time. 

While working on this, I also noticed that the steps UI crashes if you drag it all the way to 0, so this increases the resolution, while also preventing them from going below 1.

Takes guidance from this issue https://github.com/apple/ml-stable-diffusion/issues/85, specifically `progress.currentImages`. These images are included in the progress object already, so there shouldn't be any impact on performance.

Example video:

https://github.com/huggingface/swift-coreml-diffusers/assets/1981179/188213d1-2b77-493f-a85f-5bde7e81a337

iPhone format:
<img width="600" alt="Screenshot 2023-07-06 at 5 08 30 PM" src="https://github.com/huggingface/swift-coreml-diffusers/assets/1981179/ab694ffd-c349-4674-9498-1fce8e54546e">


