### PR TITLE
Compile fixes for Xcode 14.3.1

### DIFF
--- a/Diffusion/DiffusionApp.swift
+++ b/Diffusion/DiffusionApp.swift
@@ -22,8 +22,8 @@ let deviceHas6GBOrMore = ProcessInfo.processInfo.physicalMemory > 5924000000   /
 
 let deviceSupportsQuantization = {
     if #available(iOS 17, *) {
-        true
+        return true
     } else {
-        false
+        return false
     }
 }()


### PR DESCRIPTION
Did not compile on Xcode 14.3.1

Cannot convert value of type '()' to expected condition type 'Bool'

